### PR TITLE
Add option to exclude file types from asset check fixes #286

### DIFF
--- a/frontend/src/modules/frameworkImport/templates/frameworkImport.hbs
+++ b/frontend/src/modules/frameworkImport/templates/frameworkImport.hbs
@@ -23,12 +23,21 @@
           {{/if}}
         </div>
         <div class="field field-assets">
-            <label for="tags">{{t 'app.importassetfolderstitle'}}</label>
+            <label for="formAssetFolders">{{t 'app.importassetfolderstitle'}}</label>
             <div class="field-help">
               {{t 'app.importassetfoldersinstruction'}}
             </div>
             <div>
               <input type="text" autocomplete="off" class="width-30" id="formAssetFolders" name="formAssetFolders" placeholder="{{t 'app.importassetfoldersplaceholder'}}" value="" />
+            </div>
+        </div>
+        <div class="field field-asset-excludes">
+            <label for="formAssetExcludes">{{t 'app.importassetexcludesstitle'}}</label>
+            <div class="field-help">
+              {{t 'app.importassetexcludesinstruction'}}
+            </div>
+            <div>
+              <input type="text" autocomplete="off" class="width-30" id="formAssetExcludes" name="formAssetExcludes" value="" />
             </div>
         </div>
         <div class="field field-tags">

--- a/plugins/output/adapt/helpers.js
+++ b/plugins/output/adapt/helpers.js
@@ -118,13 +118,13 @@ function importPlugin(pluginDir, pluginType, pluginImported) {
 * @param {object} metadata
 * @param {callback} assetImported
 */
-function importAsset(fileMetadata, metadata, assetImported) {
+function importAsset(formAssetExcludes, fileMetadata, metadata, assetImported) {
   var search = {
     filename: fileMetadata.filename,
     size: fileMetadata.size
   };
   origin.assetmanager.retrieveAsset(search, function gotAsset(error, results) {
-    if(results.length > 0) {
+    if(results.length > 0 && !formAssetExcludes.includes(fileMetadata.type)) {
       metadata.idMap[fileMetadata.oldId] = results[0]._id;
       if (metadata.assetNameMap) {
         metadata.assetNameMap[results[0]._id] = results[0].filename;

--- a/routes/lang/en-application.json
+++ b/routes/lang/en-application.json
@@ -337,6 +337,8 @@
   "app.importassetfoldersinstruction": "Enter the names of folders that contain assets. If there are multiple folders enter a comma seperated list. Automatically checks for the following folders if no value is entered: assets, images, video, audio.",
   "app.importassetfolderstitle": "Asset Folders",
   "app.importassetfoldersplaceholder": "assets, images, video, audio",
+  "app.importassetexcludesinstruction": "Enter the extensions of files that should not be checked for duplicates. If there are multiple file types enter a comma seperated list. Imported assets with file extensions listed here will not be checked to see if they already exist.",
+  "app.importassetexcludesstitle": "Assets Check Exclusions",
   "app.importinvalidpackage": "Encountered an unexpected file structure. Please check you have uploaded a valid export package and try again.",
   "app.cleanassets": "Clean Assets",
   "app.cleanassetsmessage": "You have removed the orphaned assets from this course.",


### PR DESCRIPTION
On import user can add a comma separated list of file extensions that will not be checked to see if the asset file already exists in the AT instance.

